### PR TITLE
Workaround for strange bug in existing visualization code

### DIFF
--- a/visualization/main.py
+++ b/visualization/main.py
@@ -655,10 +655,8 @@ def load_xai_records(config: dict) -> list:
     xai_dir = generate_xai_dir(config=config)
     file_path = join(xai_dir, config['xai']['xai_records'])
     paths_to_xai_records = load_pickle(file_path=file_path)
-    # Temporary fix for running locally
-    paths_to_xai_records = [s.strip('/mnt/') for s in paths_to_xai_records]
     data_list = list()
-    for p in tqdm(paths_to_xai_records[:10]):
+    for p in tqdm(paths_to_xai_records):
         results = load_pickle(file_path=p)
         for xai_records in results:
             data_list += [asdict(xai_records)]


### PR DESCRIPTION
Process for explictily creating a legend for the seaborn barplot and exporting it as a figure stopped working. Specifically, creating a legend for the purpose of exporting it as a figure did not work anymore. 

```
h = sns.barplot(x=xai_methods_per_word, y=attribution_scores_per_word, hue=xai_methods_per_word)
handles, labels = h.get_legend_handles_labels()
```
Although `xai_methods_per_word` and `xai_methods_per_word` are not empty, `h.get_legend_handles_labels()` return empty objects. Promblem might be related to `hue` parameter that is used to visualize the data of different categories in one plot. However, further investigation did not solve the problem. Different version of matplotlib were also checked.

The current alternative solution is customly creating a legend as follows

```
# GPT-4 generated code
# Get the unique colors of the bars
colors = [p.get_facecolor() for p in h.patches]
# Create custom legend
legend_patches = [plt.Rectangle((0,0),1,1, facecolor=colors[i]) for i in range(len(xai_methods_per_word))]            
```

The process for exporting the legend as figure remains the same. 

I would suggest merging this with main to have a working version of the code. And then create a new brancha again for creating model-specific xai visualization plots.