### PR TITLE
Add tf-idf normalization

### DIFF
--- a/configs/gender_project_config.json
+++ b/configs/gender_project_config.json
@@ -13,14 +13,8 @@
     "data_scenario": "nlp-benchmark_2024-03-04-12-44-28",
     "data_dir": "./artifacts/data",
     "tags": {
-      "gender_all": [
-        "train",
-        "eval"
-      ],
-      "gender_subj": [
-        "train",
-        "eval"
-      ]
+      "gender_all": ["train", "eval"],
+      "gender_subj": ["train", "eval"]
     }
   },
   "training": {
@@ -46,10 +40,7 @@
         "learning_rate": 0.0001,
         "model_name": "bert_randomly_init_embedding_classification",
         "model_performance": "bert_only_embedding_history",
-        "layers_to_train": [
-          "bert.embeddings",
-          "classifier"
-        ]
+        "layers_to_train": ["bert.embeddings", "classifier"]
       },
       "bert_only_classification": {
         "batch_size": 32,
@@ -57,9 +48,7 @@
         "learning_rate": 0.0001,
         "model_name": "bert_only_classification",
         "model_performance": "bert_only_classification_history",
-        "layers_to_train": [
-          "classifier"
-        ]
+        "layers_to_train": ["classifier"]
       },
       "bert_only_embedding_classification": {
         "batch_size": 32,
@@ -67,10 +56,7 @@
         "learning_rate": 0.0001,
         "model_name": "bert_only_embedding_classification",
         "model_performance": "bert_only_embedding_classification_history",
-        "layers_to_train": [
-          "bert.embeddings",
-          "classification"
-        ]
+        "layers_to_train": ["bert.embeddings", "classification"]
       },
       "bert_all": {
         "batch_size": 32,
@@ -111,15 +97,12 @@
     "output_dir": "visualization_gender",
     "absolute_dir_to_project": "/home/rick/research/xai-nlp-benchmark",
     "visualizations": {
-      "data": [
-        "correlation_plot"
-      ],
-      "model": [
-        "model_performance"
-      ],
+      "data": ["correlation_plot"],
+      "model": ["model_performance"],
       "_xai": [
-        "_most_common_xai_attributions",
-        "most_common_xai_attributions_normalized",
+        "most_common_xai_attributions",
+        "most_common_xai_attributions_tf_idf",
+        "most_common_xai_attributions_freq",
         "sentence_html_plot"
       ],
       "evaluation": [

--- a/configs/sentiment_project_config.json
+++ b/configs/sentiment_project_config.json
@@ -13,18 +13,10 @@
     "data_scenario": "nlp-benchmark_2024-03-04-12-44-28",
     "data_dir": "./artifacts/data",
     "tags": {
-      "sentiment_twitter": [
-        "train"
-      ],
-      "sentiment_imdb": [
-        "train"
-      ],
-      "gender_all": [
-        "eval"
-      ],
-      "gender_subj": [
-        "eval"
-      ]
+      "sentiment_twitter": ["train"],
+      "sentiment_imdb": ["train"],
+      "gender_all": ["eval"],
+      "gender_subj": ["eval"]
     }
   },
   "training": {
@@ -50,10 +42,7 @@
         "learning_rate": 0.0001,
         "model_name": "bert_randomly_init_embedding_classification",
         "model_performance": "bert_only_embedding_history",
-        "layers_to_train": [
-          "bert.embeddings",
-          "classifier"
-        ]
+        "layers_to_train": ["bert.embeddings", "classifier"]
       },
       "bert_only_classification": {
         "batch_size": 32,
@@ -61,9 +50,7 @@
         "learning_rate": 0.0001,
         "model_name": "bert_only_classification",
         "model_performance": "bert_only_classification_history",
-        "layers_to_train": [
-          "classifier"
-        ]
+        "layers_to_train": ["classifier"]
       },
       "bert_only_embedding_classification": {
         "batch_size": 32,
@@ -71,10 +58,7 @@
         "learning_rate": 0.0001,
         "model_name": "bert_only_embedding_classification",
         "model_performance": "bert_only_embedding_classification_history",
-        "layers_to_train": [
-          "bert.embeddings",
-          "classification"
-        ]
+        "layers_to_train": ["bert.embeddings", "classification"]
       },
       "bert_all": {
         "batch_size": 32,
@@ -117,7 +101,8 @@
     "visualizations": {
       "xai": [
         "most_common_xai_attributions",
-        "most_common_xai_attributions_normalized"
+        "most_common_xai_attributions_tf_idf",
+        "most_common_xai_attributions_freq"
       ],
       "prediction": [
         "prediction_positive",
@@ -125,9 +110,7 @@
         "prediction_diff",
         "sentence_wise_attribution_diff"
       ],
-      "evaluation": [
-        "mass_accuracy"
-      ]
+      "evaluation": ["mass_accuracy"]
     }
   }
 }


### PR DESCRIPTION
Use tf-idf to normalize attributions instead of word frequency.

![most_common_xai_attributions_normalized](https://github.com/braindatalab/xai-nlp-benchmark/assets/22524997/810e149a-350d-47dc-ac39-0aa8dec014c1)
