### PR TITLE
Add relative mass accuracy score

### DIFF
--- a/visualization/common.py
+++ b/visualization/common.py
@@ -25,6 +25,8 @@ METRIC_NAME_MAP = dict(
     mass_accuracy='Mass Accuracy (MA)',
     mass_accuracy_method_grouped="Mass Accuracy (MA)",
     mass_accuracy_reversed="1 - Mass Accuracy (MA)",
+    mass_accuracy_relative="Relative Mass Accuracy (MA)",
+    mass_accuracy_relative_grouped="Relative Mass Accuracy (MA)",
 )
 
 METHOD_NAME_MAP = dict(Covariance="Pattern Variant")


### PR DESCRIPTION
I added a relative caculation of the mass accuracy. Since we calculate the performance score per sentence, I extract the feature attributions of a particular model, here `bert_zero_shot`, and merge it into the existing evaluation dataframe, such that all attributions for each BERT model variant also have the corresponding attributions of the zero-shot BERT per sentence.